### PR TITLE
Fix profile page detection

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -33,8 +33,9 @@ function detectPageContext() {
     };
   }
 
-  // Check for user profile (e.g., /username but not /username/status/xxx)
-  const userProfileMatch = pathname.match(/^\/([^\/]+)$/);
+  // Check for user profile (e.g., /username or /username/ but not /username/status/xxx)
+  // Allow optional trailing slash which previous regex failed to match
+  const userProfileMatch = pathname.match(/^\/([^\/]+)\/?$/);
   if (
     userProfileMatch &&
     !pathname.includes("/status/") &&


### PR DESCRIPTION
## Summary
- handle trailing slash in user profile path detection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6862b984a9dc832fb80d9b900680013c